### PR TITLE
Add console-based native injector entry point

### DIFF
--- a/src/ALBIS_NI.cpp
+++ b/src/ALBIS_NI.cpp
@@ -1,0 +1,107 @@
+#include "stdafx.h"
+#include "InjectionCore.h"
+
+#include <iostream>
+#include <iomanip>
+#include <memory>
+
+namespace
+{
+    constexpr wchar_t kTargetProcessName[] = L"TargetProcess.exe";
+    constexpr wchar_t kPayloadDllName[] = L"Payload.dll";
+
+    std::wstring BuildDllPath()
+    {
+        return blackbone::Utils::GetExeDirectory() + L"\\" + kPayloadDllName;
+    }
+
+    bool LoadImage(const std::wstring& path, vecPEImages& images)
+    {
+        auto image = std::make_shared<blackbone::pe::PEImage>();
+        NTSTATUS status = image->Load(path);
+        if (!NT_SUCCESS(status))
+        {
+            std::wcerr << L"[!] 지정된 DLL을 불러올 수 없습니다: " << path
+                       << L" (NTSTATUS 0x" << std::hex << std::setw(8) << std::setfill(L'0') << status << std::dec << L")" << std::endl;
+            std::wcerr << std::setfill(L' ');
+            return false;
+        }
+
+        images.emplace_back(std::move(image));
+        return true;
+    }
+
+    bool ResolveTargetProcess(uint32_t& pid)
+    {
+        auto pids = blackbone::Process::EnumByName(kTargetProcessName);
+        if (pids.empty())
+        {
+            std::wcerr << L"[!] 대상 프로세스를 찾을 수 없습니다: " << kTargetProcessName << std::endl;
+            return false;
+        }
+
+        pid = pids.front();
+        return true;
+    }
+}
+
+int wmain()
+{
+    SetConsoleOutputCP(CP_UTF8);
+
+    std::wcout << L"[+] ALBIS Native Injector를 시작합니다." << std::endl;
+
+    HWND consoleWindow = nullptr;
+    InjectionCore injector(consoleWindow);
+
+    InjectContext context;
+    context.cfg.procName = kTargetProcessName;
+    context.cfg.processMode = Existing;
+    context.cfg.injectMode = Normal;
+    context.cfg.hijack = true;
+    context.cfg.unlink = true;
+    context.cfg.erasePE = true;
+    context.cfg.procCmdLine.clear();
+    context.cfg.initRoutine.clear();
+    context.cfg.initArgs.clear();
+    context.cfg.mmapFlags = 0;
+    context.cfg.delay = 0;
+    context.cfg.period = 0;
+    context.cfg.skipProc = 0;
+    context.cfg.close = false;
+    context.cfg.krnHandle = false;
+    context.cfg.injIndef = false;
+
+    const std::wstring dllPath = BuildDllPath();
+    context.cfg.images.clear();
+    context.cfg.images.emplace_back(dllPath);
+
+    if (!LoadImage(dllPath, context.images))
+        return 1;
+
+    uint32_t pid = 0;
+    if (!ResolveTargetProcess(pid))
+        return 1;
+
+    context.pid = pid;
+    context.cfg.pid = pid;
+    context.procPath = kTargetProcessName;
+
+    std::wcout << L"[+] 대상 프로세스: " << kTargetProcessName << L" (PID=" << pid << L")" << std::endl;
+    std::wcout << L"[+] 주입 DLL 경로: " << dllPath << std::endl;
+
+    NTSTATUS status = injector.InjectMultiple(&context);
+    if (!NT_SUCCESS(status))
+    {
+        auto description = blackbone::Utils::GetErrorDescription(status);
+        std::wcerr << L"[!] 인젝션에 실패했습니다. NTSTATUS=0x" << std::hex << std::setw(8) << std::setfill(L'0') << status << std::dec;
+        if (!description.empty())
+            std::wcerr << L" (" << description << L")";
+        std::wcerr << std::endl;
+        std::wcerr << std::setfill(L' ');
+        return 1;
+    }
+
+    std::wcout << L"[+] 인젝션이 성공적으로 완료되었습니다." << std::endl;
+    return 0;
+}

--- a/src/Xenos.vcxproj
+++ b/src/Xenos.vcxproj
@@ -109,7 +109,7 @@
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <SubSystem>Windows</SubSystem>
+      <SubSystem>Console</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <FixedBaseAddress>true</FixedBaseAddress>
       <TargetMachine>MachineX86</TargetMachine>
@@ -136,7 +136,7 @@
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <SubSystem>Windows</SubSystem>
+      <SubSystem>Console</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <FixedBaseAddress>true</FixedBaseAddress>
       <AdditionalDependencies>Shlwapi.lib;Dbghelp.lib;Comctl32.lib;mscoree.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -161,7 +161,7 @@
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <SubSystem>Windows</SubSystem>
+      <SubSystem>Console</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
@@ -190,7 +190,7 @@
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <SubSystem>Windows</SubSystem>
+      <SubSystem>Console</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
@@ -206,7 +206,7 @@
     <ClCompile Include="DumpHandler.cpp" />
     <ClCompile Include="FileUtil.cpp" />
     <ClCompile Include="InjectionCore.cpp" />
-    <ClCompile Include="Main.cpp" />
+    <ClCompile Include="ALBIS_NI.cpp" />
     <ClCompile Include="MainDlg.cpp" />
     <ClCompile Include="Routines.cpp" />
     <ClCompile Include="DlgModules.cpp" />

--- a/src/Xenos.vcxproj.filters
+++ b/src/Xenos.vcxproj.filters
@@ -1,7 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <ClCompile Include="Main.cpp" />
+    <ClCompile Include="ALBIS_NI.cpp">
+      <Filter>Core</Filter>
+    </ClCompile>
     <ClCompile Include="DlgModules.cpp">
       <Filter>Interface\ModuleView</Filter>
     </ClCompile>


### PR DESCRIPTION
## Summary
- add the new `ALBIS_NI.cpp` console entry point that performs native injection into a fixed target with mandatory unlink, header erase, and thread hijack options
- switch the project to build as a console subsystem and include the new source file in the build

## Testing
- `dotnet build Xenos.sln` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c93c7bb3f08332b8247d68186f726b